### PR TITLE
reduce learning curve by removing unnecessary wrappers

### DIFF
--- a/src/hive/components/screens/home/route.cljs
+++ b/src/hive/components/screens/home/route.cljs
@@ -127,7 +127,7 @@
   "basic navigation directions"
   [props]
   (let [window  (tool/keywordize (.. fl/ReactNative (Dimensions/get "window")))
-        id      (work/q queries/user-id)
+        id      (data/q queries/user-id (work/db))
         data   @(work/pull! [{:user/city [:city/geometry :city/bbox :city/name]}
                              {:user/route [:route/routes :route/departure]}
                              :user/goal]

--- a/src/hive/components/screens/home/welcome.cljs
+++ b/src/hive/components/screens/home/welcome.cljs
@@ -10,7 +10,8 @@
             [clojure.string :as str]
             [cljs.pprint :as pprint]
             [cljs.spec.alpha :as s]
-            [hive.libs.geometry :as geometry]))
+            [hive.libs.geometry :as geometry]
+            [datascript.core :as data]))
 
 (s/def ::type     #{"success"})
 (s/def ::errorCode nil?)
@@ -40,10 +41,11 @@
   [props]
   (let [navigate (:navigate (:navigation props))
         redirectUrl  (oops/ocall fl/Expo "AuthSession.getRedirectUrl")
-        [domain cid] (work/q '[:find [?domain ?id]
+        [domain cid] (data/q '[:find [?domain ?id]
                                :where [_ :ENV/AUTH0_DOMAIN ?domain]
-                                      [_ :ENV/CLIENT_ID ?id]])
-        id       (work/q queries/user-id)
+                                      [_ :ENV/CLIENT_ID ?id]]
+                             (work/db))
+        id       (data/q queries/user-id (work/db))
         info    @(work/pull! [{:user/city [:city/geometry :city/bbox :city/name]}]
                              [:user/id id])
         coords   (:coordinates (:city/geometry (:user/city info)))

--- a/src/hive/core.cljs
+++ b/src/hive/core.cljs
@@ -79,8 +79,7 @@
   (let [conn   (data/create-conn state/schema)
         data   (cons {:session/uuid (data/squuid)
                       :session/start (js/Date.now)}
-                     state/init-data)
-        config (reload-config! [:user/city])]
+                     state/init-data)]
     (work/init! conn)
     (work/transact! data)
     (location/watch! position/defaults)
@@ -89,7 +88,8 @@
     (oops/ocall fl/ReactNative "BackHandler.addEventListener"
                 "hardwareBackPress"
                 back-listener)
-    (let [id      (data/q queries/user-id (work/db))
+    (let [config (reload-config! [:user/city])
+          id      (data/q queries/user-id (work/db))
           default (assoc state/defaults :user/id id)
           tx      (async/into [default] config)]
       (work/transact! tx))))

--- a/src/hive/rework/core.cljs
+++ b/src/hive/rework/core.cljs
@@ -96,26 +96,11 @@
   (set! state/conn dsconn)
   (rtx/listen! state/conn))
 
-(defn pull
-  "same as datascript pull but uses the app state as connection"
-  [selector eid]
-  (data/pull @state/conn selector eid))
-
 (defn pull!
   "same as datascript/pull but returns a ratom which will be updated
   every time that the value of conn changes"
   [selector eid]
   (r/track rtx/pull* (::rtx/ratom @state/conn) selector eid))
-
-(defn entity
-  "same as datascript/entity but uses the app state as connection"
-  [eid]
-  (data/entity @state/conn eid))
-
-(defn q
-  "same as datascript/q but uses the app state as connection"
-  [query & inputs]
-  (apply data/q query @state/conn inputs))
 
 (defn q!
   "Returns a reagent/atom with the result of the query.
@@ -123,6 +108,15 @@
   a change is detected"
   [query & inputs]
   (r/track rtx/q* query (::rtx/ratom @state/conn) inputs))
+
+(defn db
+  "return the Datascript Database instance that rework currently uses.
+  The returned version is immutable, therefore you cannot use
+  datascript/transact!.
+
+  This is meant to keep querying separate from mutations"
+  []
+  @state/conn)
 
 (defn transact!
   "'Updates' the DataScript state with data.
@@ -162,15 +156,6 @@
     (js/console.error (clj->js data))))
     ;:else (do (println "unknown transact! type argument" data)
     ;          data))) ;; js/Errors, side effects with no return value ...
-
-(defn inject
-  "runs query with provided inputs and associates its result into m
-  under key"
-  ([m key query & inputs]
-   (let [result (apply q query inputs)]
-     (assoc m key result)))
-  ([key query] ;; not possible to have & inputs due to conflict with upper args
-   (fn inject* [m] (inject m key query))))
 
 ;(data/transact! (:conn @app) [{:user/city [:city/name "Frankfurt am Main"]}])
 

--- a/src/hive/rework/tx.cljs
+++ b/src/hive/rework/tx.cljs
@@ -51,9 +51,3 @@
    Useful to use with reagent/track"
   [ratom selector eid]
   (data/pull @ratom selector eid))
-
-(defn entity*
-  "same as datascript/entity but takes a reagent/atom as connection.
-   Useful to use with reagent/track"
-  [ratom eid]
-  (data/entity @ratom eid))

--- a/src/hive/rework/util.cljs
+++ b/src/hive/rework/util.cljs
@@ -23,7 +23,7 @@
 ;; HACK: https://stackoverflow.com/questions/27746304/how-do-i-tell-if-an-object-is-a-promise
 (defn promise?
   [value]
-  (exists? (.-then value)))
+  (and (some? value) (exists? (.-then value))))
 
 (defn- print-warning!
   [e pipe request]

--- a/src/hive/services/location.cljs
+++ b/src/hive/services/location.cljs
@@ -2,7 +2,8 @@
   (:require [hive.rework.core :as work]
             [hive.services.raw.location :as location]
             [hive.rework.util :as tool]
-            [hive.queries :as queries]))
+            [hive.queries :as queries]
+            [datascript.core :as data]))
 
 (defn tx-position
   [data]
@@ -10,7 +11,7 @@
     :user/position (dissoc data :user/id)}])
 
 (def update-position (comp tx-position
-                           (work/inject :user/id queries/user-id)
+                           #(assoc % :user/id (data/q queries/user-id (work/db)))
                            location/point
                            tool/keywordize))
 


### PR DESCRIPTION
This PR promotes the use of Clojure and Datascript api instead of our own to solve common tasks.

- pull removed -> use datascript pull
- q removed -> use datascript q
- entity removed -> use datascript entity
- inject removed -> use assoc and q

fixes #103 -> expose only reactive functions and rely on Datascript for the rest