### PR TITLE
Quickwin

### DIFF
--- a/src/hive/components/screens/home/core.cljs
+++ b/src/hive/components/screens/home/core.cljs
@@ -29,11 +29,9 @@
         position (data/pull db [:user/position] [:user/id user])
         start    (:coordinates (:geometry (:user/position position)))
         end      (:coordinates (:geometry target))
-        now      (new DateTime)
-        [url opts] (kamal/directions [start end] now)]
+        now      (new DateTime)]
     [[{:user/id user :user/goal target}]
-     (delay (.. (js/fetch url (clj->js opts))
-                (then #(.json %))
+     (delay (.. (kamal/directions! [start end] now)
                 (then #(route/process-directions % user now))))
      (delay (.. fl/ReactNative (Keyboard.dismiss)))
      [navigate "directions"]]))
@@ -86,9 +84,7 @@
       (if (tool/error? validated)
         [[navigate "location-error" validated]
          (delay (.. fl/ReactNative (Keyboard.dismiss)))]
-        [(delay (.. (js/fetch (mapbox/geocoding args))
-                    (then #(. ^js/Response % json))
-                    (then tool/keywordize)
+        [(delay (.. (mapbox/geocoding! args)
                     (then #(assoc % :user/id user))
                     (then update-places)))]))))
 

--- a/src/hive/components/screens/home/route.cljs
+++ b/src/hive/components/screens/home/route.cljs
@@ -106,6 +106,8 @@
        (duration/format (* 1000 (:duration route)))]]
      [:> react/Text {:style {:color "gray" :paddingLeft "2.5%"}} poi]]))
 
+(def section-height 140)
+
 (defn Instructions
   "basic navigation directions"
   [props]
@@ -113,6 +115,9 @@
         id      (data/q queries/user-id (work/db))
         data   @(work/pull! [{:user/route [:route/route :route/uuid]}]
                             [:user/id id])
+        sections (partition-by :mode (:steps (:route/route (:user/route data))))
+        overview-height (* section-height (count sections))
+        info-height     (* 0.1 (:height window))
         path    (sequence (comp (map :geometry)
                                 (map :coordinates)
                                 (mapcat #(drop-last %))
@@ -124,8 +129,9 @@
           [:> expo/MapPolyline {:coordinates path
                                 :strokeColor "#3bb2d0"
                                 :strokeWidth 4}]]]
-      [:> react/View {:height (* 1.1 (:height window)) :backgroundColor "white"}
-        [Info {:flex 1 :paddingTop "1%"} id]
+      [:> react/View {:height (+ info-height overview-height)
+                      :backgroundColor "white"}
+        [Info {:height info-height :paddingTop "1%"} id]
         [Route {:flex 9} id]]
       [:> react/View (merge (symbols/circle 52) symbols/shadow
                             {:position "absolute" :right "10%"

--- a/src/hive/components/screens/home/route.cljs
+++ b/src/hive/components/screens/home/route.cljs
@@ -18,12 +18,9 @@
   "takes a mapbox directions response and returns it.
    Return an exception if no path was found"
   [path user now]
-  (if (not= (goog.object/get path "code"))
-    (ex-info (goog.object/get "msg") path)
-    (let [path (js->clj path :keywordize-keys true)]
-      [(tool/with-ns :route (assoc path :departure now))
-       {:user/id user
-        :user/route [:route/uuid (:uuid path)]}])))
+  [(tool/with-ns :route (assoc path :departure now))
+   {:user/id user
+    :user/route [:route/uuid (:uuid path)]}])
 
 (def big-circle (symbols/circle 16))
 (def small-circle (symbols/circle 12))

--- a/src/hive/rework/core.cljs
+++ b/src/hive/rework/core.cljs
@@ -100,14 +100,14 @@
   "same as datascript/pull but returns a ratom which will be updated
   every time that the value of conn changes"
   [selector eid]
-  (r/track rtx/pull* (::rtx/ratom @state/conn) selector eid))
+  (r/track! rtx/pull* (::rtx/ratom @state/conn) selector eid))
 
 (defn q!
   "Returns a reagent/atom with the result of the query.
   The value of the ratom will be automatically updated whenever
   a change is detected"
   [query & inputs]
-  (r/track rtx/q* query (::rtx/ratom @state/conn) inputs))
+  (r/track! rtx/q* query (::rtx/ratom @state/conn) inputs))
 
 (defn db
   "return the Datascript Database instance that rework currently uses.

--- a/src/hive/services/kamal.cljs
+++ b/src/hive/services/kamal.cljs
@@ -36,6 +36,6 @@
     (.. (js/fetch url (clj->js opts))
         (then (fn [^js/Response response] (. response (json))))
         (then (fn [result]
-                (if (= (goog.object/get result "code") "Ok")
+                (if (= (. result -code) "Ok")
                   (js->clj result :keywordize-keys true)
                   (js/Promise.reject (ex-info (goog.object/get "msg") result))))))))

--- a/src/hive/services/kamal.cljs
+++ b/src/hive/services/kamal.cljs
@@ -23,3 +23,19 @@
                 (str/replace "{departure}" (local-time departure)))]
     [url {:method "GET"
           :headers {:Accept "application/json"}}]))
+
+(defn directions!
+  "executes the result of directions with js/fetch.
+
+  Returns a Promise with a Clojure data structure.
+
+  Rejects when status not= Ok"
+  ^js/Promise
+  [coordinates departure]
+  (let [[url opts] (directions coordinates departure)]
+    (.. (js/fetch url (clj->js opts))
+        (then (fn [^js/Response response] (. response (json))))
+        (then (fn [result]
+                (if (= (goog.object/get result "code") "Ok")
+                  (js->clj result :keywordize-keys true)
+                  (js/Promise.reject (ex-info (goog.object/get "msg") result))))))))

--- a/src/hive/services/mapbox.cljs
+++ b/src/hive/services/mapbox.cljs
@@ -1,7 +1,8 @@
 (ns hive.services.mapbox
   (:require [clojure.string :as str]
             [cljs.spec.alpha :as s]
-            [hiposfer.geojson.specs :as geojson]))
+            [hiposfer.geojson.specs :as geojson]
+            [hive.rework.util :as tool]))
 
 (s/def ::input (s/and string? not-empty))
 (s/def ::query (s/or :location ::input
@@ -43,3 +44,13 @@
                 (str/replace "{query}" (js/encodeURIComponent (:query request)))
                 (str/replace "{params}" (str/join "&" params)))]
       URL))
+
+(defn geocoding!
+  "executes the result of geocoding with js/fetch.
+
+  Returns a promise with a Clojure datastructure"
+  ^js/Promise
+  [request]
+  (.. (js/fetch (geocoding request))
+      (then (fn [^js/Response res] (. res (json))))
+      (then tool/keywordize)))


### PR DESCRIPTION
- cosmetic changes
- make `work/pull!` and `work/q!` eager ... before they would return nothing on the first call which means that a re-render would happen once the data arrives ... not good
- make height of instructions section adapt to amount of info returned by kamal