### PR TITLE
Transact - refactored

### DIFF
--- a/src/hive/components/screens/errors.cljs
+++ b/src/hive/components/screens/errors.cljs
@@ -37,7 +37,7 @@
           :on-press #(goBack)}
          [:> expo/Ionicons {:name "ios-close-circle" :size 30}]]
        [:> react/TouchableOpacity
-         {:on-press #(run! work/transact! (launch-location-settings goBack))
+         {:on-press #(work/transact! (launch-location-settings goBack))
           :style {:borderRadius 5 :backgroundColor "lawngreen"
                   :height 40 :width 60 :flexDirection "row"
                   :alignItems "center" :justifyContent "space-around"}}

--- a/src/hive/components/screens/home/core.cljs
+++ b/src/hive/components/screens/home/core.cljs
@@ -27,7 +27,7 @@
         position (data/pull db [:user/position] [:user/id user])
         start    (:coordinates (:geometry (:user/position position)))
         end      (:coordinates (:geometry target))]
-    [[{:user/id user :user/goal target}]
+    [{:user/id user :user/goal target}
      (delay (.. (kamal/directions! [start end] (new DateTime))
                 (then #(route/process-directions % user))))
                 ;; TODO: error handling
@@ -49,7 +49,7 @@
        ^{:key (:id target)}
        [:> react/TouchableOpacity
          {:style    {:flex 1 :flexDirection "row"}
-          :on-press #(run! work/transact! (set-target (work/db) navigate target))}
+          :onPress #(work/transact! (set-target (work/db) navigate target))}
          [:> react/View {:flex 0.2 :alignItems "center" :justifyContent "flex-end"}
            [:> expo/Ionicons {:name "ios-pin" :size 26 :color "red"}]
            [:> react/Text {:note true} (str (. distance (toPrecision 2)) " km")]]
@@ -106,7 +106,7 @@
      [:> react/Input {:placeholder "Where would you like to go?"
                       :ref #(vreset! ref %) :style {:flex 0.9}
                       :underlineColorAndroid "transparent"
-                      :onChangeText #(run! work/transact! (autocomplete % (work/db) props))}]]))
+                      :onChangeText #(work/transact! (autocomplete % (work/db) props))}]]))
 
 (defn Home
   "The main screen of the app. Contains a search bar and a mapview"

--- a/src/hive/components/screens/home/welcome.cljs
+++ b/src/hive/components/screens/home/welcome.cljs
@@ -61,7 +61,7 @@
                              :shadowColor "#000000" :shadowRadius 20
                              :shadowOffset {:width 0 :height 10} :shadowOpacity 1.0}}
        [:> react/TouchableOpacity {:style {:flex 1 :alignItems "center" :justifyContent "center"}
-                                   :onPress #(work/transact! [log-in! domain cid redirectUrl])}
+                                   :onPress #(work/transact! [[log-in! domain cid redirectUrl]])}
          [:> react/Text {:style {:color "white" :fontWeight "bold" :fontSize 15}}
                         "Login"]]]]))
 

--- a/src/hive/components/screens/settings/city_picker.cljs
+++ b/src/hive/components/screens/settings/city_picker.cljs
@@ -14,7 +14,7 @@
         goBack (:goBack (:navigation props))
         tx     {:user/id user
                 :user/city [:city/name (:city/name city)]}]
-    [[tx]
+    [tx
      [store/save! (select-keys tx [:user/city])]
      [goBack]]))
 
@@ -22,7 +22,7 @@
   [props]
   (let [params   (:params (:state (:navigation props)))
         city     (:city props)]
-    [:> react/TouchableOpacity {:onPress #(run! work/transact! (change-city city props))}
+    [:> react/TouchableOpacity {:onPress #(work/transact! (change-city city props))}
      [:> react/View {:style {:height 55 :borderBottomColor "lightgray"
                              :borderBottomWidth 1 :paddingTop 5}}
       [symbols/PointOfInterest

--- a/src/hive/rework/core.cljs
+++ b/src/hive/rework/core.cljs
@@ -118,51 +118,58 @@
   []
   @state/conn)
 
+(declare transact!)
+
+(defn- execute!
+  [result value]
+  ;; async transaction - transact each element
+  (when (tool/chan? value)
+    (async/reduce (fn [_ v] (transact! v)) nil value))
+
+  ;; JS promise - wait for its value then transact it
+  (when (tool/promise? value)
+    (. value (then transact!)))
+
+  (cond
+    ;; functional side effect declaration
+    ;; Execute it and try to execute its result
+    (and (vector? value) (fn? (first value)))
+    (do (execute! [] (apply (first value) (rest value)))
+        (identity result))
+
+    ;; side effect declaration wrapped with delay to allow testing
+    ;; Force it and try to execute its result
+    (delay? value)
+    (do (execute! result (deref value))
+        (identity result))
+
+    ;; simple datascript transaction
+    (or (map? value) (vector? value))
+    (conj result value)
+    ;; otherwise just keep reducing
+    :else result))
+
 (defn transact!
-  "'Updates' the DataScript state with data.
+  "Single entry point for 'updating' the app state. The behaviour of
+  transact! depends on the arguments.
 
    data can be:
-   - a standard Datomic transaction. See Datomic's API documentation for more
+   - a standard Datascript transaction. See Datomic's API documentation for more
     information. http://docs.datomic.com/transactions.html
-   - a channel containing one or more transactions
+   - a channel yielding one or more transactions
    - a vector whose first element is a function and the rest are its argument.
-     The function will be executed and its return value is passed to transact!
-     again. Useful for keeping functions side-effect free
-   - a delay whose content will be forced and passed to transact! again.
-     Useful for keeping function side-effect free when doing Js interop
-   - a Js Promise, whose return value will be transact. Useful for doing
-     asynchronous Js calls without having to convert it to a core async channel
-
-   Returns Datascript transact! return value or a channel
-   with the content of each transact! result.
+     The function will be executed and its return value is used in-place of
+     the original one. Useful for keeping functions side-effect free
+   - a delay whose content will be forced. Its return value is used in-place
+     of the original one. Useful for side-effect free Js interop
+   - a Js Promise yielding a single transaction. Useful for doing
+     asynchronous Js calls without converting them to a async channel
 
    Not supported data types are ignored"
   [data]
-  (cond
-    ;; async transaction - transact each element
-    (tool/chan? data)
-    (let [c (async/chan 1 (map transact!))]
-      (async/pipe data c))
-    ;; JS promise - wait for its value then transact it
-    (tool/promise? data)
-    (.. data (then transact!))
-    ;; functional side effect declaration
-    ;; Execute it and try to transact it
-    (and (vector? data) (fn? (first data)))
-    (recur (apply (first data) (rest data)))
-    ;; side effect declaration wrapped with DelayJS to allow testing
-    ;; Force it and try to transact it
-    (delay? data)
-    (recur (deref data))
-    ;; simple transaction
-    (sequential? data)
-    (data/transact! state/conn data)
-    ;; useful for debugging
-    (tool/error? data)
-    (js/console.error (clj->js data))))
-    ;:else (do (println "unknown transact! type argument" data)
-    ;          data))) ;; js/Errors, side effects with no return value ...
-
+  (when (sequential? data)
+    (let [tx (reduce execute! [] data)]
+      (data/transact! state/conn tx))))
 ;(data/transact! (:conn @app) [{:user/city [:city/name "Frankfurt am Main"]}])
 
 ;(q '[:find [(pull ?entity [*]) ...]

--- a/src/hive/rework/core.cljs
+++ b/src/hive/rework/core.cljs
@@ -140,7 +140,7 @@
     ;; side effect declaration wrapped with delay to allow testing
     ;; Force it and try to execute its result
     (delay? value)
-    (do (execute! result (deref value))
+    (do (execute! [] (deref value))
         (identity result))
 
     ;; simple datascript transaction


### PR DESCRIPTION
Previously we had to do `(run! transact! (my-custom-transaction))` to execute a series of transactions together with side-effects.

This worked well for some cases, however, in the case of asynchronous function the behaviour was not clear. Since the user was the one executing the transaction (when it is available) we were forced to assume that the result of a promise was a single transaction element.

The problem arises when the result of one promise is meant to create more promises together with a transaction. There was just no way to do this before. In particular, the case that I had was that the result from `kamal directions/` endpoint returns GTFS entities which I also want to request from `kamal` (such as trip headsign or route color/type), but there was no way to do this due to the assumption above.

This PR attempts to change that merging together Datascript transactions with `effect` execution and asynchronous function.

From now on, all `effects` are executed first and then we update the Datascript db with the transaction.