### PR TITLE
fix: ip command in ubuntu was not returning proper ip

### DIFF
--- a/src/hive/services/location.cljs
+++ b/src/hive/services/location.cljs
@@ -3,7 +3,6 @@
             [react-native :as React]
             [expo :as Expo]
             [hive.state.queries :as queries]
-            [hive.state.queries :as queries]
             [datascript.core :as data]))
 
 ;; todo: should altitude be inside the point coordinates?


### PR DESCRIPTION
fix: duplicated require

NOTE: now that I used my linux machine, I also get a loading map by default (even though I am using the frankfurt area .... I will check this further)