### PR TITLE
Logging

### DIFF
--- a/js/figwheel-bridge.js
+++ b/js/figwheel-bridge.js
@@ -157,9 +157,9 @@ function importJs(src, success, error) {
 
 function interceptRequire() {
     var oldRequire = window.require;
-    console.info("Shimming require");
+    logDebug("Shimming require");
     window.require = function (id) {
-        console.info("Requiring: " + id);
+        logDebug("Requiring: " + id);
         if (externalModules[id]) {
             return externalModules[id];
         }
@@ -220,7 +220,8 @@ function loadApp(platform, devHost, onLoadCb) {
     };
 
     if (typeof goog === "undefined") {
-        console.info('Loading Closure base.');
+        console.log(`--------- DEBUGGING LOGS: ${debugEnabled === true ? "enabled" : "disabled"}`)
+        logDebug('Loading Closure base.');
         interceptRequire();
 
         // need to know base path here
@@ -252,7 +253,7 @@ function figwheelImportScript(uri, callback) {
 
 // Goog fixes
 function shimBaseGoog(basePath) {
-    console.info('Shimming goog functions.');
+    logDebug('Shimming goog functions.');
     goog.basePath = basePath + '/' + config.googBasePath;
     goog.global.FIGWHEEL_WEBSOCKET_CLASS = WebSocket;
     goog.global.FIGWHEEL_IMPORT_SCRIPT = figwheelImportScript;

--- a/js/figwheel-bridge.js
+++ b/js/figwheel-bridge.js
@@ -220,7 +220,7 @@ function loadApp(platform, devHost, onLoadCb) {
     };
 
     if (typeof goog === "undefined") {
-        console.log(`--------- DEBUGGING LOGS: ${debugEnabled === true ? "enabled" : "disabled"}`)
+        console.log(`--------- FIGWHEEL BRIDGE LOGS: ${debugEnabled === true ? "enabled" : "disabled"}`)
         logDebug('Loading Closure base.');
         interceptRequire();
 

--- a/src/hive/services/kamal.cljs
+++ b/src/hive/services/kamal.cljs
@@ -14,7 +14,7 @@
      (str/replace gtime " " "T"))))
 
 ;(def template "https://hive-6c54a.appspot.com/directions/v5")
-(def server "https://kamal-germany.herokuapp.com")
+(def server "https://kamal-live.herokuapp.com")
 (def urls
   {:area/directions "{server}/area/frankfurt/directions?coordinates={coordinates}&departure={departure}"
    :area/entity     "{server}/area/frankfurt/{entity}/{id}"

--- a/src/hive/state/core.cljs
+++ b/src/hive/state/core.cljs
@@ -166,9 +166,6 @@
                            (and (vector? v) (fn? (first v)))
                            (into [(.-name (first v))] (rest v))
 
-                           (tool/error? v)
-                           (ex-message v)
-
                            :else v))
                        args)))
 

--- a/src/hive/state/core.cljs
+++ b/src/hive/state/core.cljs
@@ -178,10 +178,11 @@
     (tool/promise? value)
     (let [id (data/squuid)]
       (js/console.table "awaiting promise -" (pr-str id))
-      (. value (then (fn [result]
-                       (js/console.log "promise" (pr-str id) "resolved")
-                       (log! result)
-                       (identity result)))))
+      (.. value (then (fn [result]
+                        (js/console.log "promise" (pr-str id) "resolved")
+                        (log! result)
+                        (identity result)))
+                (catch (fn [error] (js/console.warn "promise" (pr-str id) "error UNHANDLED" error)))))
 
     ;; functional side effect declaration
     ;; Execute it and try to execute its result


### PR DESCRIPTION
- fixes #111 
- fix: wrong heroku url

### implementation notes
- every element passed to transact! is logged with a clear type, status and other information for clear debugging
- only logs on development
- catches all unhandled promises and logs exactly which promise failed (using and ID)